### PR TITLE
map list: show difficulties as color-coded blobs

### DIFF
--- a/map_list/create.tsx
+++ b/map_list/create.tsx
@@ -6,12 +6,13 @@ import { observer } from 'mobx-react';
 import { Api } from 'pages/paradb/base/api/api';
 import { RouteLink } from 'pages/paradb/base/text/link';
 import { T } from 'pages/paradb/base/text/text';
-import { MapList } from 'pages/paradb/map_list/map_list';
+import { ComplexityColorPills, MapList } from 'pages/paradb/map_list/map_list';
 import { MapListPresenter, MapListStore } from 'pages/paradb/map_list/map_list_presenter';
 import { routeFor, RoutePath } from 'pages/paradb/router/routes';
 import { PDMap, serializeMap } from 'paradb-api-schema';
 import React from 'react';
 import styles from './map_list.css';
+import metrics from 'pages/paradb/base/metrics/metrics.css';
 
 const naturalSort = (getProp: (map: PDMap) => string | undefined) => {
   return (a: PDMap, b: PDMap) => {
@@ -34,7 +35,7 @@ export function createMapList(api: Api) {
   const store = new MapListStore();
   const presenter = new MapListPresenter(api, store);
 
-  const getRow = (map: PDMap): Row<4> => {
+  const getRow = (map: PDMap): Row<5> => {
     const onSelect = action((e: React.MouseEvent<HTMLAnchorElement>) => {
       if (!store.enableBulkSelect) {
         return;
@@ -63,6 +64,7 @@ export function createMapList(api: Api) {
         React.memo(() => wrapWithMapRoute(<T.Small>{map.title}</T.Small>)),
         React.memo(() => wrapWithMapRoute(<T.Small>{map.artist}</T.Small>)),
         React.memo(() => wrapWithMapRoute(<T.Small>{map.author}</T.Small>)),
+        React.memo(() => wrapWithMapRoute(<ComplexityColorPills complexities={map.complexities}/>)),
         React.memo(() =>
             wrapWithMapRoute(
                 <T.Small>{formatDate(map.submissionDate)}</T.Small>,
@@ -87,6 +89,11 @@ export function createMapList(api: Api) {
       {
         content: <T.Small weight="bold">Mapper</T.Small>,
         sort: naturalSort(m => m.author),
+      },
+      {
+        content: <T.Small weight="bold">Difficulties</T.Small>,
+        sort: naturalSort(m => m.complexities.map(c => c.complexityName).join()),
+        width: `calc(${metrics.gridBaseline} * 13)`,
       },
       {
         content: <T.Small weight="bold">Upload date</T.Small>,

--- a/map_list/map_list.css
+++ b/map_list/map_list.css
@@ -72,3 +72,14 @@
     display: flex;
     justify-content: center;
 }
+
+.complexities {
+    display: flex;
+    gap: gridBaseline;
+}
+
+.complexityColorPill {
+    width: calc(gridBaseline * 2);
+    height: calc(gridBaseline * 2);
+    border-radius: 50%;
+}

--- a/map_list/map_list.tsx
+++ b/map_list/map_list.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames';
 import { observer } from 'mobx-react';
 import { Button } from 'pages/paradb/base/ui/button/button';
 import { Textbox } from 'pages/paradb/base/ui/textbox/textbox';
+import { Complexity } from 'paradb-api-schema';
 import React from 'react';
 import styles from './map_list.css';
 
@@ -16,6 +17,31 @@ type Props = {
   onClickCancelBulkSelect(): void,
   onChangeFilterQuery(val: string): void,
 };
+
+function getComplexityColor(complexity: number) {
+  switch (complexity) {
+    case 1:
+      return 'green';
+    case 2:
+      return 'yellow';
+    case 3:
+      return 'orange';
+    case 4:
+      return 'red';
+    case 5:
+      return 'black';
+    default:
+      throw new Error(`Did not expect complexity level ${complexity}`);
+  }
+}
+
+export const ComplexityColorPills = (props: { complexities: Complexity[] }) => (
+  <div className={styles.complexities}>
+    {props.complexities.map((c, i) => (
+        <div key={i} className={styles.complexityColorPill} style={{ backgroundColor: getComplexityColor(c.complexity)}}></div>
+    ))}
+  </div>
+);
 
 @observer
 export class MapList extends React.Component<Props> {


### PR DESCRIPTION
This PR adds color-coded circles to indicate the available difficulties directly on the map list.

|Difficulty|Color|
|---|---|
|Easy|Green|
|Medium|Yellow|
|Hard|Orange|
|Expert|Red|
|Expert+|Black|

![image](https://user-images.githubusercontent.com/4076797/159228134-109072a7-aa01-4384-a15d-6babf2245bbf.png)
