### PR TITLE
refactor(maps): migrate to zip.js with ranged reading

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,7 @@
         "@types/react-dom": "19.2.3",
         "@types/sanitize-html": "^2.9.0",
         "@vercel/functions": "^3.3.4",
+        "@zip.js/zip.js": "^2.8.34",
         "camelcase-keys-recursive": "^1.0.0",
         "classnames": "^2.3.2",
         "encoding": "^0.1.13",
@@ -44,7 +45,6 @@
         "snakecase-keys": "^5.4.6",
         "tsx": "^4.19.3",
         "typescript": "5.1.6",
-        "unzipper": "^0.12.3",
         "zapatos": "^6.6.1",
         "zod": "^4.3.4",
         "zxcvbn": "^4.4.2",
@@ -62,7 +62,6 @@
         "@types/postcss-modules-values": "^4",
         "@types/qs": "^6.9.8",
         "@types/supertest": "^2.0.12",
-        "@types/unzipper": "^0.10.7",
         "@types/zxcvbn": "^4.4.2",
         "dotenv-cli": "^11.0.0",
         "jest": "^29.7.0",
@@ -999,8 +998,6 @@
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
-    "@types/unzipper": ["@types/unzipper@0.10.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-D25im2zjyMCcgL9ag6N46+wbtJBnXIr7SI4zHf9eJD2Dw2tEB5e+p5MYkrxKIVRscs5QV0EhtU9rgXSPx90oJg=="],
-
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@types/yargs": ["@types/yargs@17.0.35", "", { "dependencies": { "@types/yargs-parser": "*" } }, "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg=="],
@@ -1111,6 +1108,8 @@
 
     "@xtuc/long": ["@xtuc/long@4.2.2", "", {}, "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="],
 
+    "@zip.js/zip.js": ["@zip.js/zip.js@2.8.34", "", {}, "sha512-+6a3lyqq69rpseLbvDPiVIWsZ/HdTGAAD6afFtug6ECPDGttb2dHnPC6cJgdPofYkzL9OvXizegq+DQVfL2rnA=="],
+
     "acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
 
     "acorn-import-attributes": ["acorn-import-attributes@1.9.5", "", { "peerDependencies": { "acorn": "^8" } }, "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ=="],
@@ -1194,8 +1193,6 @@
     "baseline-browser-mapping": ["baseline-browser-mapping@2.9.11", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ=="],
 
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
-
-    "bluebird": ["bluebird@3.7.2", "", {}, "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="],
 
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
 
@@ -1281,8 +1278,6 @@
 
     "cookiejar": ["cookiejar@2.1.4", "", {}, "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw=="],
 
-    "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
-
     "create-jest": ["create-jest@29.7.0", "", { "dependencies": { "@jest/types": "^29.6.3", "chalk": "^4.0.0", "exit": "^0.1.2", "graceful-fs": "^4.2.9", "jest-config": "^29.7.0", "jest-util": "^29.7.0", "prompts": "^2.0.1" }, "bin": { "create-jest": "bin/create-jest.js" } }, "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q=="],
 
     "create-require": ["create-require@1.1.1", "", {}, "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="],
@@ -1362,8 +1357,6 @@
     "dotenv-expand": ["dotenv-expand@12.0.3", "", { "dependencies": { "dotenv": "^16.4.5" } }, "sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
-
-    "duplexer2": ["duplexer2@0.1.4", "", { "dependencies": { "readable-stream": "^2.0.2" } }, "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA=="],
 
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
 
@@ -1512,8 +1505,6 @@
     "forwarded-parse": ["forwarded-parse@2.1.2", "", {}, "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw=="],
 
     "fraction.js": ["fraction.js@5.3.4", "", {}, "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ=="],
-
-    "fs-extra": ["fs-extra@11.3.3", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg=="],
 
     "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
 
@@ -1693,7 +1684,7 @@
 
     "is-weakset": ["is-weakset@2.0.4", "", { "dependencies": { "call-bound": "^1.0.3", "get-intrinsic": "^1.2.6" } }, "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ=="],
 
-    "isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
+    "isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
@@ -1784,8 +1775,6 @@
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
     "jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
-
-    "jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
 
     "jsx-ast-utils": ["jsx-ast-utils@3.3.5", "", { "dependencies": { "array-includes": "^3.1.6", "array.prototype.flat": "^1.3.1", "object.assign": "^4.1.4", "object.values": "^1.1.6" } }, "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ=="],
 
@@ -2119,8 +2108,6 @@
 
     "pretty-format": ["pretty-format@29.7.0", "", { "dependencies": { "@jest/schemas": "^29.6.3", "ansi-styles": "^5.0.0", "react-is": "^18.0.0" } }, "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ=="],
 
-    "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
-
     "progress": ["progress@2.0.3", "", {}, "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="],
 
     "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
@@ -2146,8 +2133,6 @@
     "react-dom": ["react-dom@19.2.0", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.0" } }, "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ=="],
 
     "react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
-
-    "readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
     "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
@@ -2287,8 +2272,6 @@
 
     "string.prototype.trimstart": ["string.prototype.trimstart@1.0.8", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg=="],
 
-    "string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
-
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 
     "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
@@ -2381,13 +2364,9 @@
 
     "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
 
-    "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
-
     "unplugin": ["unplugin@1.0.1", "", { "dependencies": { "acorn": "^8.8.1", "chokidar": "^3.5.3", "webpack-sources": "^3.2.3", "webpack-virtual-modules": "^0.5.0" } }, "sha512-aqrHaVBWW1JVKBHmGo33T5TxeL0qWzfvjWokObHA9bYmN7eNDkwOxmLjhioHl9878qDFMAaT51XNroRyuz7WxA=="],
 
     "unrs-resolver": ["unrs-resolver@1.11.1", "", { "dependencies": { "napi-postinstall": "^0.3.0" }, "optionalDependencies": { "@unrs/resolver-binding-android-arm-eabi": "1.11.1", "@unrs/resolver-binding-android-arm64": "1.11.1", "@unrs/resolver-binding-darwin-arm64": "1.11.1", "@unrs/resolver-binding-darwin-x64": "1.11.1", "@unrs/resolver-binding-freebsd-x64": "1.11.1", "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1", "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1", "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1", "@unrs/resolver-binding-linux-arm64-musl": "1.11.1", "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1", "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1", "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1", "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1", "@unrs/resolver-binding-linux-x64-gnu": "1.11.1", "@unrs/resolver-binding-linux-x64-musl": "1.11.1", "@unrs/resolver-binding-wasm32-wasi": "1.11.1", "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1", "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1", "@unrs/resolver-binding-win32-x64-msvc": "1.11.1" } }, "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg=="],
-
-    "unzipper": ["unzipper@0.12.3", "", { "dependencies": { "bluebird": "~3.7.2", "duplexer2": "~0.1.4", "fs-extra": "^11.2.0", "graceful-fs": "^4.2.2", "node-int64": "^0.4.0" } }, "sha512-PZ8hTS+AqcGxsaQntl3IRBw65QrBI6lxzqDEL7IAo/XCEqRTKGfOX56Vea5TH9SZczRVxuzk1re04z/YjuYCJA=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
@@ -2655,10 +2634,6 @@
 
     "readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
-    "safe-array-concat/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
-
-    "safe-push-apply/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
-
     "schema-utils/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
     "sharp/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
@@ -2692,8 +2667,6 @@
     "v8-to-istanbul/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "webpack/eslint-scope": ["eslint-scope@5.1.1", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^4.1.1" } }, "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw=="],
-
-    "which-builtin-type/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,6 @@
         "@zip.js/zip.js": "^2.8.34",
         "camelcase-keys-recursive": "^1.0.0",
         "classnames": "^2.3.2",
-        "encoding": "^0.1.13",
         "eslint": "^9",
         "eslint-config-next": "16.0.3",
         "flags": "^4.0.2",

--- a/e2e/helpers/zip.ts
+++ b/e2e/helpers/zip.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import * as unzipper from 'unzipper';
+import { FileEntry, Uint8ArrayReader, ZipReader } from '@zip.js/zip.js';
 import { MapFixture } from '../fixtures';
 
 /**
@@ -8,15 +8,18 @@ import { MapFixture } from '../fixtures';
  * serves the uploaded bytes verbatim, so this round-trips the whole upload -> S3 -> download flow.
  */
 export async function assertZipMatchesFixture(zipBuffer: Buffer, fixture: MapFixture) {
-  const directory = await unzipper.Open.buffer(zipBuffer);
-  const filePaths = directory.files.filter((f) => f.type === 'File').map((f) => f.path);
+  const entries = await new ZipReader(new Uint8ArrayReader(zipBuffer)).getEntries();
+  const files = entries.filter((e): e is FileEntry => !e.directory);
 
   for (const entry of fixture.expectedEntries) {
-    expect(filePaths, `downloaded zip should contain ${entry}`).toContain(entry);
+    expect(
+      files.map((f) => f.filename),
+      `downloaded zip should contain ${entry}`
+    ).toContain(entry);
   }
 
-  const rlrr = directory.files.find((f) => f.path.endsWith('.rlrr'));
+  const rlrr = files.find((f) => f.filename.endsWith('.rlrr'));
   expect(rlrr, 'downloaded zip should contain a .rlrr').toBeTruthy();
-  const metadata = JSON.parse((await rlrr!.buffer()).toString());
+  const metadata = JSON.parse(Buffer.from(await rlrr!.arrayBuffer()).toString());
   expect(metadata.recordingMetadata.title).toBe(fixture.title);
 }

--- a/e2e/helpers/zip.ts
+++ b/e2e/helpers/zip.ts
@@ -7,7 +7,10 @@ import { MapFixture } from '../fixtures';
  * expected file entry, and its .rlrr still carries the fixture's title. The download path stores and
  * serves the uploaded bytes verbatim, so this round-trips the whole upload -> S3 -> download flow.
  */
-export async function assertZipMatchesFixture(zipBuffer: Buffer, fixture: MapFixture) {
+export async function assertZipMatchesFixture(
+  zipBuffer: Buffer,
+  fixture: MapFixture
+): Promise<void> {
   const entries = await new ZipReader(new Uint8ArrayReader(zipBuffer)).getEntries();
   const files = entries.filter((e): e is FileEntry => !e.directory);
   const filenames = files.map((f) => f.filename);

--- a/e2e/helpers/zip.ts
+++ b/e2e/helpers/zip.ts
@@ -10,12 +10,10 @@ import { MapFixture } from '../fixtures';
 export async function assertZipMatchesFixture(zipBuffer: Buffer, fixture: MapFixture) {
   const entries = await new ZipReader(new Uint8ArrayReader(zipBuffer)).getEntries();
   const files = entries.filter((e): e is FileEntry => !e.directory);
+  const filenames = files.map((f) => f.filename);
 
   for (const entry of fixture.expectedEntries) {
-    expect(
-      files.map((f) => f.filename),
-      `downloaded zip should contain ${entry}`
-    ).toContain(entry);
+    expect(filenames, `downloaded zip should contain ${entry}`).toContain(entry);
   }
 
   const rlrr = files.find((f) => f.filename.endsWith('.rlrr'));

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@types/react-dom": "19.2.3",
     "@types/sanitize-html": "^2.9.0",
     "@vercel/functions": "^3.3.4",
+    "@zip.js/zip.js": "^2.8.34",
     "camelcase-keys-recursive": "^1.0.0",
     "classnames": "^2.3.2",
     "encoding": "^0.1.13",
@@ -59,7 +60,6 @@
     "snakecase-keys": "^5.4.6",
     "tsx": "^4.19.3",
     "typescript": "5.1.6",
-    "unzipper": "^0.12.3",
     "zapatos": "^6.6.1",
     "zod": "^4.3.4",
     "zxcvbn": "^4.4.2"
@@ -77,7 +77,6 @@
     "@types/postcss-modules-values": "^4",
     "@types/qs": "^6.9.8",
     "@types/supertest": "^2.0.12",
-    "@types/unzipper": "^0.10.7",
     "@types/zxcvbn": "^4.4.2",
     "dotenv-cli": "^11.0.0",
     "jest": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@zip.js/zip.js": "^2.8.34",
     "camelcase-keys-recursive": "^1.0.0",
     "classnames": "^2.3.2",
-    "encoding": "^0.1.13",
     "eslint": "^9",
     "eslint-config-next": "16.0.3",
     "flags": "^4.0.2",

--- a/src/app/api/maps/submit/complete/complete_upload.ts
+++ b/src/app/api/maps/submit/complete/complete_upload.ts
@@ -69,19 +69,19 @@ export async function completeMapUpload(id: string, isReupload: boolean) {
     }
   }
 
-  // Fetch it and begin processing
-  const getMapResult = await s3Handler.getMapFile(id, true);
-  if (!getMapResult.success) {
+  // Open it for reading and begin processing
+  const openMapResult = await s3Handler.openMapFile(id, true);
+  if (!openMapResult.success) {
     await cleanupFailedUpload();
     return actionError({
       errorBody: {},
       message: 'The file could not be processed.',
-      resultError: getMapResult,
+      resultError: openMapResult,
       shouldLog: true,
     });
   }
-  const mapFile = getMapResult.value;
-  if (mapFile.byteLength > 1024 * 1024 * 100) {
+  const archive = openMapResult.value;
+  if (archive.size > 1024 * 1024 * 100) {
     await cleanupFailedUpload();
     // 100MiB. We use MiB because that's what Windows displays in Explorer and therefore what users will expect.
     return actionError({
@@ -91,7 +91,7 @@ export async function completeMapUpload(id: string, isReupload: boolean) {
   }
   const processMapResult = await mapsRepo.validateUploadedMap({
     id,
-    mapFile,
+    archive,
     uploader: session.id,
   });
   if (!processMapResult.success) {

--- a/src/services/maps/map_validator.ts
+++ b/src/services/maps/map_validator.ts
@@ -1,9 +1,8 @@
-import { FileEntry, ZipReader } from '@zip.js/zip.js';
+import { FileEntry, Reader, ZipReader } from '@zip.js/zip.js';
 import { PromisedResult, Result, ResultError } from 'base/result';
 import { PDMap } from 'schema/maps';
 // @ts-expect-error - encoding does not provide types
 import * as encoding from 'encoding';
-import { MapArchive } from 'services/maps/s3_handler_types';
 import { readEntry, zipBasename, zipDirname } from 'services/maps/zip';
 
 type RawMap = Pick<
@@ -27,14 +26,14 @@ export const enum ValidateMapDifficultyError {
 
 export async function validateMap(opts: {
   id: string;
-  archive: MapArchive;
+  reader: Reader<unknown>;
 }): PromisedResult<
   RawMap & { albumArtFiles: FileEntry[] },
   ValidateMapError | ValidateMapDifficultyError
 > {
   let files: FileEntry[];
   try {
-    const entries = await new ZipReader(opts.archive.reader).getEntries();
+    const entries = await new ZipReader(opts.reader).getEntries();
     files = entries.filter((e): e is FileEntry => !e.directory);
   } catch {
     // Failed to open zip -- corrupted, or incorrect format

--- a/src/services/maps/map_validator.ts
+++ b/src/services/maps/map_validator.ts
@@ -1,9 +1,9 @@
+import { FileEntry, Uint8ArrayReader, ZipReader } from '@zip.js/zip.js';
 import { PromisedResult, Result, ResultError } from 'base/result';
 import { PDMap } from 'schema/maps';
 // @ts-expect-error - encoding does not provide types
 import * as encoding from 'encoding';
-import path from 'path';
-import * as unzipper from 'unzipper';
+import { readEntry, zipBasename, zipDirname } from 'services/maps/zip';
 
 type RawMap = Pick<
   PDMap,
@@ -28,24 +28,27 @@ export async function validateMap(opts: {
   id: string;
   buffer: Buffer;
 }): PromisedResult<
-  RawMap & { albumArtFiles: unzipper.File[] },
+  RawMap & { albumArtFiles: FileEntry[] },
   ValidateMapError | ValidateMapDifficultyError
 > {
-  let map: unzipper.CentralDirectory;
+  let files: FileEntry[];
   try {
-    map = await unzipper.Open.buffer(opts.buffer);
+    const entries = await new ZipReader(new Uint8ArrayReader(opts.buffer)).getEntries();
+    files = entries.filter((e): e is FileEntry => !e.directory);
   } catch {
     // Failed to open zip -- corrupted, or incorrect format
     return { success: false, errors: [{ type: ValidateMapError.NO_DATA }] };
   }
+  if (files.length === 0) {
+    return { success: false, errors: [{ type: ValidateMapError.NO_DATA }] };
+  }
   // A submitted map must have exactly one directory in it, and all of the files must be directly
   // under that directory.
-  const files = map.files.filter((f) => f.type === 'File');
-  let mapName = files[0].path.match(/(.+?)\//)?.[1];
+  let mapName = files[0].filename.match(/(.+?)\//)?.[1];
   if (mapName?.startsWith('/')) {
     mapName = mapName.substring(1);
   }
-  if (mapName == null || !files.every((f) => path.dirname(f.path) === mapName)) {
+  if (mapName == null || !files.every((f) => zipDirname(f.filename) === mapName)) {
     return { success: false, errors: [{ type: ValidateMapError.INCORRECT_FOLDER_STRUCTURE }] };
   }
   const validatedResult = validateMapFiles({ expectedMapName: mapName, mapFiles: files });
@@ -61,24 +64,24 @@ type RawMapMetadata = Pick<
 >;
 async function validateMapFiles(opts: {
   expectedMapName: string;
-  mapFiles: unzipper.File[];
+  mapFiles: FileEntry[];
 }): PromisedResult<
-  RawMap & { albumArtFiles: unzipper.File[] },
+  RawMap & { albumArtFiles: FileEntry[] },
   ValidateMapError | ValidateMapDifficultyError
 > {
   // The map directory needs to have the same name as the rlrr files.
   // TODO: remove this check once Paradiddle supports arbitrary folder names
-  const difficultyFiles = opts.mapFiles.filter((f) => f.path.endsWith('.rlrr'));
-  if (!difficultyFiles.every((f) => path.basename(f.path).startsWith(opts.expectedMapName))) {
+  const difficultyFiles = opts.mapFiles.filter((f) => f.filename.endsWith('.rlrr'));
+  if (!difficultyFiles.every((f) => zipBasename(f.filename).startsWith(opts.expectedMapName))) {
     return { success: false, errors: [{ type: ValidateMapError.INCORRECT_FOLDER_NAME }] };
   }
   // Gets a file in the map archive, relative to the primary map directory
   const getMapFile = (filename: string) =>
-    opts.mapFiles.find((f) => f.path === `${opts.expectedMapName}${path.sep}${filename}`);
+    opts.mapFiles.find((f) => f.filename === `${opts.expectedMapName}/${filename}`);
 
   const difficultyResults = await Promise.all(
     difficultyFiles.map((f) =>
-      f.buffer().then((b) => validateMapDifficulty(path.basename(f.path), b, getMapFile))
+      readEntry(f).then((b) => validateMapDifficulty(zipBasename(f.filename), b, getMapFile))
     )
   );
   if (difficultyResults.length === 0) {
@@ -159,7 +162,7 @@ async function validateMapFiles(opts: {
 function validateMapDifficulty(
   filename: string,
   mapBuffer: Buffer,
-  getMapFile: (filename: string) => unzipper.File | undefined
+  getMapFile: (filename: string) => FileEntry | undefined
 ): Result<RawMapMetadata & { difficultyName: string }, ValidateMapDifficultyError> {
   let map: any;
   try {

--- a/src/services/maps/map_validator.ts
+++ b/src/services/maps/map_validator.ts
@@ -1,8 +1,9 @@
-import { FileEntry, Uint8ArrayReader, ZipReader } from '@zip.js/zip.js';
+import { FileEntry, ZipReader } from '@zip.js/zip.js';
 import { PromisedResult, Result, ResultError } from 'base/result';
 import { PDMap } from 'schema/maps';
 // @ts-expect-error - encoding does not provide types
 import * as encoding from 'encoding';
+import { MapArchive } from 'services/maps/s3_handler_types';
 import { readEntry, zipBasename, zipDirname } from 'services/maps/zip';
 
 type RawMap = Pick<
@@ -26,14 +27,14 @@ export const enum ValidateMapDifficultyError {
 
 export async function validateMap(opts: {
   id: string;
-  buffer: Buffer;
+  archive: MapArchive;
 }): PromisedResult<
   RawMap & { albumArtFiles: FileEntry[] },
   ValidateMapError | ValidateMapDifficultyError
 > {
   let files: FileEntry[];
   try {
-    const entries = await new ZipReader(new Uint8ArrayReader(opts.buffer)).getEntries();
+    const entries = await new ZipReader(opts.archive.reader).getEntries();
     files = entries.filter((e): e is FileEntry => !e.directory);
   } catch {
     // Failed to open zip -- corrupted, or incorrect format

--- a/src/services/maps/map_validator.ts
+++ b/src/services/maps/map_validator.ts
@@ -1,5 +1,5 @@
 import { FileEntry, Reader, ZipReader } from '@zip.js/zip.js';
-import { PromisedResult, Result, ResultError } from 'base/result';
+import { PromisedResult, Result, ResultError, wrapError } from 'base/result';
 import { PDMap } from 'schema/maps';
 // @ts-expect-error - encoding does not provide types
 import * as encoding from 'encoding';
@@ -31,28 +31,29 @@ export async function validateMap(opts: {
   RawMap & { albumArtFiles: FileEntry[] },
   ValidateMapError | ValidateMapDifficultyError
 > {
-  let files: FileEntry[];
+  // Reading an entry decompresses and CRC-checks it, and on a remote archive fetches more of it, so
+  // anything in here can throw. A throw escaping to the caller would strand the map mid-validation:
+  // its upload only gets rolled back on an error Result.
   try {
     const entries = await new ZipReader(opts.reader).getEntries();
-    files = entries.filter((e): e is FileEntry => !e.directory);
-  } catch {
-    // Failed to open zip -- corrupted, or incorrect format
-    return { success: false, errors: [{ type: ValidateMapError.NO_DATA }] };
+    const files = entries.filter((e): e is FileEntry => !e.directory);
+    if (files.length === 0) {
+      return { success: false, errors: [{ type: ValidateMapError.NO_DATA }] };
+    }
+    // A submitted map must have exactly one directory in it, and all of the files must be directly
+    // under that directory.
+    let mapName = files[0].filename.match(/(.+?)\//)?.[1];
+    if (mapName?.startsWith('/')) {
+      mapName = mapName.substring(1);
+    }
+    if (mapName == null || !files.every((f) => zipDirname(f.filename) === mapName)) {
+      return { success: false, errors: [{ type: ValidateMapError.INCORRECT_FOLDER_STRUCTURE }] };
+    }
+    return await validateMapFiles({ expectedMapName: mapName, mapFiles: files });
+  } catch (e) {
+    // Corrupted, not a zip at all, or unreadable from storage.
+    return { success: false, errors: [wrapError(e, ValidateMapError.NO_DATA)] };
   }
-  if (files.length === 0) {
-    return { success: false, errors: [{ type: ValidateMapError.NO_DATA }] };
-  }
-  // A submitted map must have exactly one directory in it, and all of the files must be directly
-  // under that directory.
-  let mapName = files[0].filename.match(/(.+?)\//)?.[1];
-  if (mapName?.startsWith('/')) {
-    mapName = mapName.substring(1);
-  }
-  if (mapName == null || !files.every((f) => zipDirname(f.filename) === mapName)) {
-    return { success: false, errors: [{ type: ValidateMapError.INCORRECT_FOLDER_STRUCTURE }] };
-  }
-  const validatedResult = validateMapFiles({ expectedMapName: mapName, mapFiles: files });
-  return validatedResult;
 }
 
 function allExists<T>(a: (T | undefined)[]): a is T[] {

--- a/src/services/maps/map_validator.ts
+++ b/src/services/maps/map_validator.ts
@@ -1,8 +1,6 @@
 import { FileEntry, Reader, ZipReader } from '@zip.js/zip.js';
 import { PromisedResult, Result, ResultError, wrapError } from 'base/result';
 import { PDMap } from 'schema/maps';
-// @ts-expect-error - encoding does not provide types
-import * as encoding from 'encoding';
 import { readEntry, zipBasename, zipDirname } from 'services/maps/zip';
 
 type RawMap = Pick<
@@ -162,12 +160,12 @@ async function validateMapFiles(opts: {
 
 function validateMapDifficulty(
   filename: string,
-  mapBuffer: Buffer,
+  rlrr: Uint8Array,
   getMapFile: (filename: string) => FileEntry | undefined
 ): Result<RawMapMetadata & { difficultyName: string }, ValidateMapDifficultyError> {
   let map: any;
   try {
-    map = parseJsonBuffer(mapBuffer);
+    map = parseJson(rlrr);
   } catch {
     return { success: false, errors: [{ type: ValidateMapDifficultyError.INVALID_FORMAT }] };
   }
@@ -251,9 +249,9 @@ function validateMapDifficulty(
   };
 }
 
-function parseJsonBuffer(buffer: Buffer) {
-  if (buffer.indexOf('\uFEFF', 0, 'utf16le') === 0) {
-    return JSON.parse(encoding.convert(buffer, 'utf8', 'utf16le'));
-  }
-  return JSON.parse(buffer.toString());
+function parseJson(bytes: Uint8Array) {
+  // Paradiddle writes some rlrr files as UTF-16LE with a byte order mark. Both decoders strip the
+  // mark themselves; leaving one in front would fail the parse.
+  const isUtf16le = bytes[0] === 0xff && bytes[1] === 0xfe;
+  return JSON.parse(new TextDecoder(isUtf16le ? 'utf-16le' : 'utf-8').decode(bytes));
 }

--- a/src/services/maps/maps_repo.ts
+++ b/src/services/maps/maps_repo.ts
@@ -21,7 +21,7 @@ import { SearchIndex } from 'services/search/types';
 import { getServerContext } from 'services/server_context';
 import snakeCaseKeys from 'snakecase-keys';
 import * as db from 'zapatos/db';
-import { S3Error, S3Handler } from './s3_handler_types';
+import { MapArchive, S3Error, S3Handler } from './s3_handler_types';
 
 const exists = <T>(t: T | undefined): t is NonNullable<T> => !!t;
 
@@ -45,8 +45,7 @@ export const enum DeleteMapError {
 type ProcessMapOpts = {
   id: string;
   uploader: string;
-  // zip file of the map
-  mapFile: Buffer;
+  archive: MapArchive;
 };
 export const enum CreateMapError {
   TOO_MANY_ID_GEN_ATTEMPTS = 'too_many_id_gen_attempts',
@@ -408,13 +407,13 @@ export class MapsRepo {
     | ValidateMapDifficultyError
     | SearchIndexError
   > {
-    const { id, mapFile: buffer, uploader } = opts;
+    const { id, archive, uploader } = opts;
     const existingMap = await this.getMap(id);
     const isExistingMap =
       existingMap.success && existingMap.value.validity === MapValidity.REUPLOADED;
 
     await this.setValidity(id, MapValidity.VALIDATING);
-    const validatedMapResult = await validateMap({ id, buffer });
+    const validatedMapResult = await validateMap({ id, archive });
     if (!validatedMapResult.success) {
       return validatedMapResult;
     }

--- a/src/services/maps/maps_repo.ts
+++ b/src/services/maps/maps_repo.ts
@@ -413,7 +413,7 @@ export class MapsRepo {
       existingMap.success && existingMap.value.validity === MapValidity.REUPLOADED;
 
     await this.setValidity(id, MapValidity.VALIDATING);
-    const validatedMapResult = await validateMap({ id, archive });
+    const validatedMapResult = await validateMap({ id, reader: archive.reader });
     if (!validatedMapResult.success) {
       return validatedMapResult;
     }

--- a/src/services/maps/s3_handler.ts
+++ b/src/services/maps/s3_handler.ts
@@ -3,17 +3,18 @@ import {
   DeleteObjectCommand,
   DeleteObjectsCommand,
   GetObjectCommand,
+  HeadObjectCommand,
   ListObjectsV2Command,
   PutObjectCommand,
   S3Client,
 } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
-import { FileEntry } from '@zip.js/zip.js';
+import { FileEntry, Reader } from '@zip.js/zip.js';
 import { checkExists } from 'base/preconditions';
 import { PromisedResult, Result, wrapError } from 'base/result';
 import { getEnvVars } from 'services/env';
 import { readEntry, zipBasename } from 'services/maps/zip';
-import { MintUploadUrlResult, S3Error, S3Handler } from './s3_handler_types';
+import { MapArchive, MintUploadUrlResult, S3Error, S3Handler } from './s3_handler_types';
 
 let s3: { client: S3Client; bucket: string } | undefined;
 
@@ -41,6 +42,40 @@ function getS3Client() {
   }
 
   return s3;
+}
+
+/** HTTP byte ranges are inclusive on both ends; S3 clamps a range that runs past the object. */
+export function rangeHeader(index: number, length: number): string {
+  return `bytes=${index}-${index + length - 1}`;
+}
+
+/** Serves a zip's reads as ranged S3 GETs, so only the bytes zip.js asks for are transferred. */
+class S3RangeReader extends Reader<string> {
+  constructor(
+    private readonly key: string,
+    size: number
+  ) {
+    super(key);
+    this.size = size;
+  }
+
+  async readUint8Array(index: number, length: number): Promise<Uint8Array> {
+    if (length === 0) {
+      return new Uint8Array(0);
+    }
+    const s3 = getS3Client();
+    const resp = await s3.client.send(
+      new GetObjectCommand({
+        Bucket: s3.bucket,
+        Key: this.key,
+        Range: rangeHeader(index, length),
+      })
+    );
+    if (!resp.Body) {
+      throw new Error(`Missing S3 body for ${this.key}`);
+    }
+    return resp.Body.transformToByteArray();
+  }
 }
 
 async function s3Get(key: string): PromisedResult<Buffer, S3Error> {
@@ -202,8 +237,30 @@ export class RealS3Handler implements S3Handler {
     };
   }
 
-  async getMapFile(id: string, temp: boolean): PromisedResult<Buffer, S3Error> {
-    return s3Get(mapKey(id, temp));
+  async openMapFile(id: string, temp: boolean): PromisedResult<MapArchive, S3Error> {
+    const key = mapKey(id, temp);
+    try {
+      const s3 = getS3Client();
+      const head = await s3.client.send(new HeadObjectCommand({ Bucket: s3.bucket, Key: key }));
+      if (head.ContentLength == null) {
+        return {
+          success: false,
+          errors: [
+            {
+              type: S3Error.S3_GET_ERROR,
+              internalMessage: 'Missing S3 content length',
+              details: { key },
+            },
+          ],
+        };
+      }
+      return {
+        success: true,
+        value: { reader: new S3RangeReader(key, head.ContentLength), size: head.ContentLength },
+      };
+    } catch (e) {
+      return { success: false, errors: [wrapError(e, S3Error.S3_GET_ERROR, { key })] };
+    }
   }
 
   async mintUploadUrl(id: string): Promise<MintUploadUrlResult> {

--- a/src/services/maps/s3_handler.ts
+++ b/src/services/maps/s3_handler.ts
@@ -9,11 +9,11 @@ import {
   S3Client,
 } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
-import { FileEntry, Reader } from '@zip.js/zip.js';
+import { FileEntry } from '@zip.js/zip.js';
 import { checkExists } from 'base/preconditions';
 import { PromisedResult, Result, wrapError } from 'base/result';
 import { getEnvVars } from 'services/env';
-import { readEntry, zipBasename } from 'services/maps/zip';
+import { RangeReader, readEntry, zipBasename } from 'services/maps/zip';
 import { MapArchive, MintUploadUrlResult, S3Error, S3Handler } from './s3_handler_types';
 
 let s3: { client: S3Client; bucket: string } | undefined;
@@ -50,19 +50,15 @@ export function rangeHeader(index: number, length: number): string {
 }
 
 /** Serves a zip's reads as ranged S3 GETs, so only the bytes zip.js asks for are transferred. */
-class S3RangeReader extends Reader<string> {
+class S3RangeReader extends RangeReader {
   constructor(
     private readonly key: string,
     size: number
   ) {
-    super(key);
-    this.size = size;
+    super(key, size);
   }
 
-  async readUint8Array(index: number, length: number): Promise<Uint8Array> {
-    if (length === 0) {
-      return new Uint8Array(0);
-    }
+  protected async fetchRange(index: number, length: number): Promise<Uint8Array> {
     const s3 = getS3Client();
     const resp = await s3.client.send(
       new GetObjectCommand({

--- a/src/services/maps/s3_handler.ts
+++ b/src/services/maps/s3_handler.ts
@@ -3,6 +3,7 @@ import {
   DeleteObjectCommand,
   DeleteObjectsCommand,
   GetObjectCommand,
+  GetObjectCommandOutput,
   HeadObjectCommand,
   ListObjectsV2Command,
   PutObjectCommand,
@@ -45,13 +46,20 @@ function getS3Client() {
 }
 
 /** HTTP byte ranges are inclusive on both ends; S3 clamps a range that runs past the object. */
-export function rangeHeader(index: number, length: number): string {
+function rangeHeader(index: number, length: number): string {
   return `bytes=${index}-${index + length - 1}`;
 }
 
+/** Just the part of `S3Client` a ranged read needs, so tests can stand one in. */
+export type RangeGetter = {
+  send(command: GetObjectCommand): Promise<GetObjectCommandOutput>;
+};
+
 /** Serves a zip's reads as ranged S3 GETs, so only the bytes zip.js asks for are transferred. */
-class S3RangeReader extends RangeReader {
+export class S3RangeReader extends RangeReader {
   constructor(
+    private readonly client: RangeGetter,
+    private readonly bucket: string,
     private readonly key: string,
     size: number
   ) {
@@ -59,10 +67,9 @@ class S3RangeReader extends RangeReader {
   }
 
   protected async fetchRange(index: number, length: number): Promise<Uint8Array> {
-    const s3 = getS3Client();
-    const resp = await s3.client.send(
+    const resp = await this.client.send(
       new GetObjectCommand({
-        Bucket: s3.bucket,
+        Bucket: this.bucket,
         Key: this.key,
         Range: rangeHeader(index, length),
       })
@@ -183,16 +190,30 @@ export class RealS3Handler implements S3Handler {
     albumArtFiles: FileEntry[],
     temp: boolean
   ): Promise<Result<string | undefined, S3Error>> {
-    // Write album art files to S3
     // TODO: display all of the album arts in the FE, e.g. in a carousel, or when selecting a difficulty
-    await Promise.all(
-      albumArtFiles.map(async (a) => {
-        const albumArt = checkExists(a, 'albumArt');
-        const buffer = await readEntry(albumArt);
-        const filename = zipBasename(albumArt.filename);
-        return s3Put(`${albumArtPrefix(id, temp)}${filename}`, buffer, guessContentType(filename));
-      })
-    );
+    let writes: Result<undefined, S3Error>[];
+    try {
+      writes = await Promise.all(
+        albumArtFiles.map(async (a) => {
+          const albumArt = checkExists(a, 'albumArt');
+          const buffer = await readEntry(albumArt);
+          const filename = zipBasename(albumArt.filename);
+          return s3Put(
+            `${albumArtPrefix(id, temp)}${filename}`,
+            buffer,
+            guessContentType(filename)
+          );
+        })
+      );
+    } catch (e) {
+      // Decompressing an entry can throw, and the caller only rolls the upload back on an error
+      // Result.
+      return { success: false, errors: [wrapError(e, S3Error.S3_WRITE_ERROR, { id })] };
+    }
+    const failed = writes.find((w) => !w.success);
+    if (failed != null && !failed.success) {
+      return failed;
+    }
 
     return {
       success: true,
@@ -219,7 +240,10 @@ export class RealS3Handler implements S3Handler {
       }
       return {
         success: true,
-        value: { reader: new S3RangeReader(key, head.ContentLength), size: head.ContentLength },
+        value: {
+          reader: new S3RangeReader(s3.client, s3.bucket, key, head.ContentLength),
+          size: head.ContentLength,
+        },
       };
     } catch (e) {
       return { success: false, errors: [wrapError(e, S3Error.S3_GET_ERROR, { key })] };

--- a/src/services/maps/s3_handler.ts
+++ b/src/services/maps/s3_handler.ts
@@ -83,7 +83,7 @@ export class S3RangeReader extends RangeReader {
 
 async function s3Put(
   key: string,
-  buffer: Buffer,
+  buffer: Uint8Array,
   contentType: string
 ): PromisedResult<undefined, S3Error> {
   try {

--- a/src/services/maps/s3_handler.ts
+++ b/src/services/maps/s3_handler.ts
@@ -8,11 +8,11 @@ import {
   S3Client,
 } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { FileEntry } from '@zip.js/zip.js';
 import { checkExists } from 'base/preconditions';
 import { PromisedResult, Result, wrapError } from 'base/result';
-import * as path from 'path';
 import { getEnvVars } from 'services/env';
-import * as unzipper from 'unzipper';
+import { readEntry, zipBasename } from 'services/maps/zip';
 import { MintUploadUrlResult, S3Error, S3Handler } from './s3_handler_types';
 
 let s3: { client: S3Client; bucket: string } | undefined;
@@ -182,7 +182,7 @@ function guessContentType(filename: string): string {
 export class RealS3Handler implements S3Handler {
   async uploadAlbumArtFiles(
     id: string,
-    albumArtFiles: unzipper.File[],
+    albumArtFiles: FileEntry[],
     temp: boolean
   ): Promise<Result<string | undefined, S3Error>> {
     // Write album art files to S3
@@ -190,15 +190,15 @@ export class RealS3Handler implements S3Handler {
     await Promise.all(
       albumArtFiles.map(async (a) => {
         const albumArt = checkExists(a, 'albumArt');
-        const buffer = await albumArt.buffer();
-        const filename = path.basename(albumArt.path);
+        const buffer = await readEntry(albumArt);
+        const filename = zipBasename(albumArt.filename);
         return s3Put(`${albumArtPrefix(id, temp)}${filename}`, buffer, guessContentType(filename));
       })
     );
 
     return {
       success: true,
-      value: albumArtFiles.length > 0 ? path.basename(albumArtFiles[0]!.path) : undefined,
+      value: albumArtFiles.length > 0 ? zipBasename(albumArtFiles[0]!.filename) : undefined,
     };
   }
 

--- a/src/services/maps/s3_handler.ts
+++ b/src/services/maps/s3_handler.ts
@@ -45,11 +45,6 @@ function getS3Client() {
   return s3;
 }
 
-/** HTTP byte ranges are inclusive on both ends; S3 clamps a range that runs past the object. */
-function rangeHeader(index: number, length: number): string {
-  return `bytes=${index}-${index + length - 1}`;
-}
-
 /** Just the part of `S3Client` a ranged read needs, so tests can stand one in. */
 export type RangeGetter = {
   send(command: GetObjectCommand): Promise<GetObjectCommandOutput>;
@@ -71,13 +66,18 @@ export class S3RangeReader extends RangeReader {
       new GetObjectCommand({
         Bucket: this.bucket,
         Key: this.key,
-        Range: rangeHeader(index, length),
+        Range: this.rangeHeader(index, length),
       })
     );
     if (!resp.Body) {
       throw new Error(`Missing S3 body for ${this.key}`);
     }
     return resp.Body.transformToByteArray();
+  }
+
+  /** HTTP byte ranges are inclusive on both ends; S3 clamps a range that runs past the object. */
+  private rangeHeader(index: number, length: number): string {
+    return `bytes=${index}-${index + length - 1}`;
   }
 }
 

--- a/src/services/maps/s3_handler.ts
+++ b/src/services/maps/s3_handler.ts
@@ -78,39 +78,6 @@ class S3RangeReader extends Reader<string> {
   }
 }
 
-async function s3Get(key: string): PromisedResult<Buffer, S3Error> {
-  try {
-    const s3 = getS3Client();
-    const resp = await s3.client.send(
-      new GetObjectCommand({
-        Bucket: s3.bucket,
-        Key: key,
-      })
-    );
-    if (!resp.Body) {
-      return {
-        success: false,
-        errors: [
-          {
-            type: S3Error.S3_GET_ERROR,
-            internalMessage: 'Missing S3 body',
-            details: { key },
-          },
-        ],
-      };
-    }
-    return {
-      success: true,
-      value: Buffer.from(await resp.Body.transformToByteArray()),
-    };
-  } catch (e) {
-    return {
-      success: false,
-      errors: [wrapError(e, S3Error.S3_GET_ERROR, { key })],
-    };
-  }
-}
-
 async function s3Put(
   key: string,
   buffer: Buffer,

--- a/src/services/maps/s3_handler_fake_disk.ts
+++ b/src/services/maps/s3_handler_fake_disk.ts
@@ -1,9 +1,10 @@
+import { FileEntry } from '@zip.js/zip.js';
 import { checkExists } from 'base/preconditions';
 import { PromisedResult, Result, wrapError } from 'base/result';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { getEnvVars } from 'services/env';
-import * as unzipper from 'unzipper';
+import { readEntry, zipBasename } from 'services/maps/zip';
 import { MintUploadUrlResult, S3Error, S3Handler } from './s3_handler_types';
 
 // Disk-backed fake S3 handler for `bun dev` (selected via S3_IMPLEMENTATION=dev). Mirrors the
@@ -73,21 +74,21 @@ export const devS3 = {
 export class FileFakeS3Handler implements S3Handler {
   async uploadAlbumArtFiles(
     id: string,
-    albumArtFiles: unzipper.File[],
+    albumArtFiles: FileEntry[],
     temp: boolean
   ): Promise<Result<string | undefined, S3Error>> {
     for (const a of albumArtFiles) {
       const albumArt = checkExists(a, 'albumArt');
-      const filename = path.basename(albumArt.path);
+      const filename = zipBasename(albumArt.filename);
       const writeResult = await writeFile(
         `${albumArtPrefix(id, temp)}${filename}`,
-        await albumArt.buffer()
+        await readEntry(albumArt)
       );
       if (!writeResult.success) return writeResult;
     }
     return {
       success: true,
-      value: albumArtFiles.length > 0 ? path.basename(albumArtFiles[0]!.path) : undefined,
+      value: albumArtFiles.length > 0 ? zipBasename(albumArtFiles[0]!.filename) : undefined,
     };
   }
 

--- a/src/services/maps/s3_handler_fake_disk.ts
+++ b/src/services/maps/s3_handler_fake_disk.ts
@@ -33,7 +33,7 @@ async function readFile(key: string): PromisedResult<Buffer, S3Error> {
   }
 }
 
-async function writeFile(key: string, body: Buffer): Promise<Result<undefined, S3Error>> {
+async function writeFile(key: string, body: Uint8Array): Promise<Result<undefined, S3Error>> {
   try {
     const filePath = devS3Path(key);
     await fs.mkdir(path.dirname(filePath), { recursive: true });
@@ -83,7 +83,7 @@ class FileRangeReader extends RangeReader {
   protected async fetchRange(index: number, length: number): Promise<Uint8Array> {
     const handle = await fs.open(this.filePath);
     try {
-      const buffer = Buffer.alloc(length);
+      const buffer = new Uint8Array(length);
       // A single read can come up short, which would leave the rest of the buffer zeroed and
       // silently corrupt what the zip parser sees.
       let read = 0;
@@ -110,7 +110,7 @@ export class FileFakeS3Handler implements S3Handler {
     for (const a of albumArtFiles) {
       const albumArt = checkExists(a, 'albumArt');
       const filename = zipBasename(albumArt.filename);
-      let entry: Buffer;
+      let entry: Uint8Array;
       try {
         entry = await readEntry(albumArt);
       } catch (e) {

--- a/src/services/maps/s3_handler_fake_disk.ts
+++ b/src/services/maps/s3_handler_fake_disk.ts
@@ -110,10 +110,15 @@ export class FileFakeS3Handler implements S3Handler {
     for (const a of albumArtFiles) {
       const albumArt = checkExists(a, 'albumArt');
       const filename = zipBasename(albumArt.filename);
-      const writeResult = await writeFile(
-        `${albumArtPrefix(id, temp)}${filename}`,
-        await readEntry(albumArt)
-      );
+      let entry: Buffer;
+      try {
+        entry = await readEntry(albumArt);
+      } catch (e) {
+        // Decompressing an entry can throw, and the caller only rolls the upload back on an error
+        // Result.
+        return { success: false, errors: [wrapError(e, S3Error.S3_WRITE_ERROR, { id })] };
+      }
+      const writeResult = await writeFile(`${albumArtPrefix(id, temp)}${filename}`, entry);
       if (!writeResult.success) return writeResult;
     }
     return {

--- a/src/services/maps/s3_handler_fake_disk.ts
+++ b/src/services/maps/s3_handler_fake_disk.ts
@@ -85,7 +85,16 @@ class FileRangeReader extends Reader<string> {
     const handle = await fs.open(this.filePath);
     try {
       const buffer = Buffer.alloc(Math.max(Math.min(length, this.size - index), 0));
-      await handle.read(buffer, 0, buffer.length, index);
+      // A single read can come up short, which would leave the rest of the buffer zeroed and
+      // silently corrupt what the zip parser sees.
+      let read = 0;
+      while (read < buffer.length) {
+        const { bytesRead } = await handle.read(buffer, read, buffer.length - read, index + read);
+        if (bytesRead === 0) {
+          return buffer.subarray(0, read);
+        }
+        read += bytesRead;
+      }
       return buffer;
     } finally {
       await handle.close();

--- a/src/services/maps/s3_handler_fake_disk.ts
+++ b/src/services/maps/s3_handler_fake_disk.ts
@@ -1,11 +1,11 @@
-import { FileEntry } from '@zip.js/zip.js';
+import { FileEntry, Reader } from '@zip.js/zip.js';
 import { checkExists } from 'base/preconditions';
 import { PromisedResult, Result, wrapError } from 'base/result';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { getEnvVars } from 'services/env';
 import { readEntry, zipBasename } from 'services/maps/zip';
-import { MintUploadUrlResult, S3Error, S3Handler } from './s3_handler_types';
+import { MapArchive, MintUploadUrlResult, S3Error, S3Handler } from './s3_handler_types';
 
 // Disk-backed fake S3 handler for `bun dev` (selected via S3_IMPLEMENTATION=dev). Mirrors the
 // key layout of the real S3 handler so the same temp -> permanent promotion flow works without
@@ -71,6 +71,28 @@ export const devS3 = {
   write: writeFile,
 };
 
+/** Disk counterpart to the real handler's ranged S3 GETs: reads only the requested bytes. */
+class FileRangeReader extends Reader<string> {
+  constructor(
+    private readonly filePath: string,
+    size: number
+  ) {
+    super(filePath);
+    this.size = size;
+  }
+
+  async readUint8Array(index: number, length: number): Promise<Uint8Array> {
+    const handle = await fs.open(this.filePath);
+    try {
+      const buffer = Buffer.alloc(Math.max(Math.min(length, this.size - index), 0));
+      await handle.read(buffer, 0, buffer.length, index);
+      return buffer;
+    } finally {
+      await handle.close();
+    }
+  }
+}
+
 export class FileFakeS3Handler implements S3Handler {
   async uploadAlbumArtFiles(
     id: string,
@@ -92,8 +114,15 @@ export class FileFakeS3Handler implements S3Handler {
     };
   }
 
-  async getMapFile(id: string, temp: boolean): PromisedResult<Buffer, S3Error> {
-    return readFile(mapKey(id, temp));
+  async openMapFile(id: string, temp: boolean): PromisedResult<MapArchive, S3Error> {
+    const key = mapKey(id, temp);
+    try {
+      const filePath = devS3Path(key);
+      const { size } = await fs.stat(filePath);
+      return { success: true, value: { reader: new FileRangeReader(filePath, size), size } };
+    } catch (e) {
+      return { success: false, errors: [wrapError(e, S3Error.S3_GET_ERROR, { key })] };
+    }
   }
 
   async mintUploadUrl(id: string): Promise<MintUploadUrlResult> {

--- a/src/services/maps/s3_handler_fake_disk.ts
+++ b/src/services/maps/s3_handler_fake_disk.ts
@@ -1,10 +1,10 @@
-import { FileEntry, Reader } from '@zip.js/zip.js';
+import { FileEntry } from '@zip.js/zip.js';
 import { checkExists } from 'base/preconditions';
 import { PromisedResult, Result, wrapError } from 'base/result';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { getEnvVars } from 'services/env';
-import { readEntry, zipBasename } from 'services/maps/zip';
+import { RangeReader, readEntry, zipBasename } from 'services/maps/zip';
 import { MapArchive, MintUploadUrlResult, S3Error, S3Handler } from './s3_handler_types';
 
 // Disk-backed fake S3 handler for `bun dev` (selected via S3_IMPLEMENTATION=dev). Mirrors the
@@ -72,19 +72,18 @@ export const devS3 = {
 };
 
 /** Disk counterpart to the real handler's ranged S3 GETs: reads only the requested bytes. */
-class FileRangeReader extends Reader<string> {
+class FileRangeReader extends RangeReader {
   constructor(
     private readonly filePath: string,
     size: number
   ) {
-    super(filePath);
-    this.size = size;
+    super(filePath, size);
   }
 
-  async readUint8Array(index: number, length: number): Promise<Uint8Array> {
+  protected async fetchRange(index: number, length: number): Promise<Uint8Array> {
     const handle = await fs.open(this.filePath);
     try {
-      const buffer = Buffer.alloc(Math.max(Math.min(length, this.size - index), 0));
+      const buffer = Buffer.alloc(length);
       // A single read can come up short, which would leave the rest of the buffer zeroed and
       // silently corrupt what the zip parser sees.
       let read = 0;

--- a/src/services/maps/s3_handler_fake_memory.ts
+++ b/src/services/maps/s3_handler_fake_memory.ts
@@ -7,7 +7,7 @@ import { MapArchive, MintUploadUrlResult, S3Error, S3Handler } from './s3_handle
  * In-memory S3 handler used in tests (selected via `S3_IMPLEMENTATION=fake`) so they don't require a
  * real S3 bucket / minio. Unlike a pure stub it actually round-trips uploaded map archives: a test
  * seeds the upload with `_putMapFileForTesting` (standing in for the client's PUT to the presigned
- * URL), and getMapFile / promoteTempMapFiles / deleteFiles then behave like the real handler's
+ * URL), and openMapFile / promoteTempMapFiles / deleteFiles then behave like the real handler's
  * temp-vs-permanent storage, so the upload-completion flow can be exercised end to end.
  */
 export class MemoryFakeS3Handler implements S3Handler {

--- a/src/services/maps/s3_handler_fake_memory.ts
+++ b/src/services/maps/s3_handler_fake_memory.ts
@@ -13,15 +13,15 @@ import { MapArchive, MintUploadUrlResult, S3Error, S3Handler } from './s3_handle
 export class MemoryFakeS3Handler implements S3Handler {
   // Map archive bytes keyed by id. Pending uploads live in `temp` and are promoted to `permanent`
   // by promoteTempMapFiles, mirroring the real handler's `.temp` suffix scheme.
-  private tempMapFiles = new Map<string, Buffer>();
-  private permanentMapFiles = new Map<string, Buffer>();
+  private tempMapFiles = new Map<string, Uint8Array>();
+  private permanentMapFiles = new Map<string, Uint8Array>();
 
   private mapFileStore(temp: boolean) {
     return temp ? this.tempMapFiles : this.permanentMapFiles;
   }
 
   /** Test seam: stand in for the client uploading a zip to the presigned URL (writes to temp). */
-  _putMapFileForTesting(id: string, buffer: Buffer) {
+  _putMapFileForTesting(id: string, buffer: Uint8Array) {
     this.tempMapFiles.set(id, buffer);
   }
 

--- a/src/services/maps/s3_handler_fake_memory.ts
+++ b/src/services/maps/s3_handler_fake_memory.ts
@@ -1,7 +1,7 @@
-import { FileEntry } from '@zip.js/zip.js';
+import { FileEntry, Uint8ArrayReader } from '@zip.js/zip.js';
 import { PromisedResult, Result } from 'base/result';
 import { zipBasename } from 'services/maps/zip';
-import { MintUploadUrlResult, S3Error, S3Handler } from './s3_handler_types';
+import { MapArchive, MintUploadUrlResult, S3Error, S3Handler } from './s3_handler_types';
 
 /**
  * In-memory S3 handler used in tests (selected via `S3_IMPLEMENTATION=fake`) so they don't require a
@@ -42,7 +42,7 @@ export class MemoryFakeS3Handler implements S3Handler {
     };
   }
 
-  async getMapFile(id: string, temp: boolean): PromisedResult<Buffer, S3Error> {
+  async openMapFile(id: string, temp: boolean): PromisedResult<MapArchive, S3Error> {
     const buffer = this.mapFileStore(temp).get(id);
     if (buffer == null) {
       return {
@@ -55,7 +55,10 @@ export class MemoryFakeS3Handler implements S3Handler {
         ],
       };
     }
-    return { success: true, value: buffer };
+    return {
+      success: true,
+      value: { reader: new Uint8ArrayReader(buffer), size: buffer.byteLength },
+    };
   }
 
   async mintUploadUrl(id: string): Promise<MintUploadUrlResult> {

--- a/src/services/maps/s3_handler_fake_memory.ts
+++ b/src/services/maps/s3_handler_fake_memory.ts
@@ -1,6 +1,6 @@
+import { FileEntry } from '@zip.js/zip.js';
 import { PromisedResult, Result } from 'base/result';
-import * as path from 'path';
-import * as unzipper from 'unzipper';
+import { zipBasename } from 'services/maps/zip';
 import { MintUploadUrlResult, S3Error, S3Handler } from './s3_handler_types';
 
 /**
@@ -33,12 +33,12 @@ export class MemoryFakeS3Handler implements S3Handler {
 
   async uploadAlbumArtFiles(
     _id: string,
-    albumArtFiles: unzipper.File[],
+    albumArtFiles: FileEntry[],
     _temp: boolean
   ): Promise<Result<string | undefined, S3Error>> {
     return {
       success: true,
-      value: albumArtFiles.length > 0 ? path.basename(albumArtFiles[0]!.path) : undefined,
+      value: albumArtFiles.length > 0 ? zipBasename(albumArtFiles[0]!.filename) : undefined,
     };
   }
 

--- a/src/services/maps/s3_handler_types.ts
+++ b/src/services/maps/s3_handler_types.ts
@@ -1,5 +1,12 @@
-import { FileEntry } from '@zip.js/zip.js';
+import { FileEntry, Reader } from '@zip.js/zip.js';
 import { PromisedResult, Result } from 'base/result';
+
+/**
+ * A map archive in blob storage, opened for random access: the zip's central directory and the few
+ * entries validation actually reads are fetched on demand, so a large archive is never held in
+ * memory in full.
+ */
+export type MapArchive = { reader: Reader<unknown>; size: number };
 
 export const enum S3Error {
   S3_GET_ERROR = 's3_get_error',
@@ -22,7 +29,7 @@ export interface S3Handler {
     albumArtFiles: FileEntry[],
     temp: boolean
   ): Promise<Result<string | undefined, S3Error>>;
-  getMapFile(id: string, temp: boolean): PromisedResult<Buffer, S3Error>;
+  openMapFile(id: string, temp: boolean): PromisedResult<MapArchive, S3Error>;
   mintUploadUrl(id: string): Promise<MintUploadUrlResult>;
   deleteFiles(id: string, temp: boolean): Promise<Result<undefined, S3Error>>;
   promoteTempMapFiles(id: string): PromisedResult<undefined, S3Error>;

--- a/src/services/maps/s3_handler_types.ts
+++ b/src/services/maps/s3_handler_types.ts
@@ -1,5 +1,5 @@
+import { FileEntry } from '@zip.js/zip.js';
 import { PromisedResult, Result } from 'base/result';
-import * as unzipper from 'unzipper';
 
 export const enum S3Error {
   S3_GET_ERROR = 's3_get_error',
@@ -19,7 +19,7 @@ export type MintUploadUrlResult =
 export interface S3Handler {
   uploadAlbumArtFiles(
     id: string,
-    albumArtFiles: unzipper.File[],
+    albumArtFiles: FileEntry[],
     temp: boolean
   ): Promise<Result<string | undefined, S3Error>>;
   getMapFile(id: string, temp: boolean): PromisedResult<Buffer, S3Error>;

--- a/src/services/maps/tests/map_generator.ts
+++ b/src/services/maps/tests/map_generator.ts
@@ -22,6 +22,8 @@ export type MapZipSpec = {
   creator?: string;
   description?: string;
   complexity?: number;
+  /** Filler, added as an extra file, to stand in for a large archive's audio. */
+  padBytes?: number;
 };
 
 export function buildMapZip(spec: MapZipSpec): Buffer {
@@ -44,7 +46,7 @@ export function buildMapZip(spec: MapZipSpec): Buffer {
   };
 
   // The .rlrr must come first: the validator derives the map name from the first file entry.
-  return buildZip([
+  const entries: ZipEntry[] = [
     {
       name: `${spec.folder}/${spec.folder}_${difficulty}.rlrr`,
       data: Buffer.from(JSON.stringify(rlrr, null, 2)),
@@ -52,7 +54,11 @@ export function buildMapZip(spec: MapZipSpec): Buffer {
     { name: `${spec.folder}/album.jpg`, data: albumArt },
     { name: `${spec.folder}/song.ogg`, data: silence },
     { name: `${spec.folder}/drums.ogg`, data: silence },
-  ]);
+  ];
+  if (spec.padBytes) {
+    entries.push({ name: `${spec.folder}/pad.bin`, data: Buffer.alloc(spec.padBytes) });
+  }
+  return buildZip(entries);
 }
 
 type ZipEntry = { name: string; data: Buffer };

--- a/src/services/maps/tests/map_generator.ts
+++ b/src/services/maps/tests/map_generator.ts
@@ -24,6 +24,8 @@ export type MapZipSpec = {
   complexity?: number;
   /** Filler, added as an extra file, to stand in for a large archive's audio. */
   padBytes?: number;
+  /** Writes the .rlrr as UTF-16LE with a byte order mark, as Paradiddle itself sometimes does. */
+  utf16le?: boolean;
 };
 
 export function buildMapZip(spec: MapZipSpec): Buffer {
@@ -49,7 +51,7 @@ export function buildMapZip(spec: MapZipSpec): Buffer {
   const entries: ZipEntry[] = [
     {
       name: `${spec.folder}/${spec.folder}_${difficulty}.rlrr`,
-      data: Buffer.from(JSON.stringify(rlrr, null, 2)),
+      data: encodeRlrr(JSON.stringify(rlrr, null, 2), spec.utf16le ?? false),
     },
     { name: `${spec.folder}/album.jpg`, data: albumArt },
     { name: `${spec.folder}/song.ogg`, data: silence },
@@ -59,6 +61,13 @@ export function buildMapZip(spec: MapZipSpec): Buffer {
     entries.push({ name: `${spec.folder}/pad.bin`, data: Buffer.alloc(spec.padBytes) });
   }
   return buildZip(entries);
+}
+
+function encodeRlrr(json: string, utf16le: boolean): Buffer {
+  if (!utf16le) {
+    return Buffer.from(json, 'utf8');
+  }
+  return Buffer.concat([Buffer.from([0xff, 0xfe]), Buffer.from(json, 'utf16le')]);
 }
 
 type ZipEntry = { name: string; data: Buffer };

--- a/src/services/maps/tests/map_generator.ts
+++ b/src/services/maps/tests/map_generator.ts
@@ -57,7 +57,7 @@ export function buildMapZip(spec: MapZipSpec): Buffer {
 
 type ZipEntry = { name: string; data: Buffer };
 
-// Minimal STORED (uncompressed) zip writer. STORED keeps this dependency-free, and `unzipper` (the
+// Minimal STORED (uncompressed) zip writer. STORED keeps this dependency-free, and zip.js (the
 // reader the validator uses) handles it; compression buys nothing for tiny test fixtures.
 function buildZip(entries: ZipEntry[]): Buffer {
   const localParts: Buffer[] = [];

--- a/src/services/maps/tests/map_validator.unit.test.ts
+++ b/src/services/maps/tests/map_validator.unit.test.ts
@@ -15,6 +15,10 @@ class CountingReader extends Reader<Uint8Array> {
     this.size = data.byteLength;
   }
 
+  async init(): Promise<void> {
+    await this.delegate.init?.();
+  }
+
   async readUint8Array(index: number, length: number): Promise<Uint8Array> {
     this.bytesRead += length;
     return this.delegate.readUint8Array(index, length);
@@ -23,13 +27,8 @@ class CountingReader extends Reader<Uint8Array> {
 
 const readFixture = (name: string) => fs.readFileSync(path.resolve(__dirname, 'files', name));
 
-const validate = (name: string) => {
-  const buffer = readFixture(name);
-  return validateMap({
-    id: 'test',
-    archive: { reader: new Uint8ArrayReader(buffer), size: buffer.byteLength },
-  });
-};
+const validate = (name: string) =>
+  validateMap({ id: 'test', reader: new Uint8ArrayReader(readFixture(name)) });
 
 const expectError = async (name: string, type: string) => {
   const result = await validate(name);
@@ -79,10 +78,7 @@ describe('validateMap', () => {
         [8 * 1024 * 1024, 32 * 1024 * 1024].map(async (padBytes) => {
           const buffer = build(padBytes);
           const reader = new CountingReader(buffer);
-          const result = await validateMap({
-            id: 'test',
-            archive: { reader, size: buffer.byteLength },
-          });
+          const result = await validateMap({ id: 'test', reader });
           expect(result.success).toBe(true);
           return reader.bytesRead;
         })

--- a/src/services/maps/tests/map_validator.unit.test.ts
+++ b/src/services/maps/tests/map_validator.unit.test.ts
@@ -77,6 +77,22 @@ describe('validateMap', () => {
       expect(result.success).toBe(true);
     });
 
+    it('a map whose rlrr is UTF-16LE with a byte order mark', async () => {
+      const buffer = buildMapZip({
+        folder: 'Test',
+        title: 'Utf16 Title',
+        artist: 'Artist',
+        utf16le: true,
+      });
+
+      const result = await validateMap({ id: 'test', reader: new Uint8ArrayReader(buffer) });
+
+      expect(result.success).toBe(true);
+      expect((result as Extract<typeof result, { success: true }>).value.title).toEqual(
+        'Utf16 Title'
+      );
+    });
+
     // The album art entries outlive the call, and are only read later, when they're uploaded to S3.
     it('returns album art entries that are still readable afterwards', async () => {
       const result = await validate('Test_valid.zip');

--- a/src/services/maps/tests/map_validator.unit.test.ts
+++ b/src/services/maps/tests/map_validator.unit.test.ts
@@ -5,6 +5,27 @@ import { validateMap } from 'services/maps/map_validator';
 import { readEntry } from 'services/maps/zip';
 import { buildMapZip } from './map_generator';
 
+class FailingReader extends Reader<Uint8Array> {
+  private reads = 0;
+  private readonly delegate: Uint8ArrayReader;
+
+  constructor(
+    data: Uint8Array,
+    private readonly failAfterReads: number
+  ) {
+    super(data);
+    this.delegate = new Uint8ArrayReader(data);
+    this.size = data.byteLength;
+  }
+
+  async readUint8Array(index: number, length: number): Promise<Uint8Array> {
+    if (this.reads++ >= this.failAfterReads) {
+      throw new Error('storage unavailable');
+    }
+    return this.delegate.readUint8Array(index, length);
+  }
+}
+
 class CountingReader extends Reader<Uint8Array> {
   bytesRead = 0;
   private readonly delegate: Uint8ArrayReader;
@@ -67,9 +88,8 @@ describe('validateMap', () => {
       expect([bytes[0], bytes[1]]).toEqual([0xff, 0xd8]);
     });
 
-    // The point of reading through a Reader: an archive is validated off its central directory and
-    // rlrr files, so blob storage never has to hand over the audio. What's read is bounded by the
-    // metadata plus zip.js' fixed-size scan for the central directory, not by the archive size.
+    // Validated off the central directory and rlrr files alone, so storage never hands over the
+    // audio. Bounded by zip.js' fixed-size central directory scan, not by the archive.
     it('reads a bounded amount regardless of how large the archive is', async () => {
       const build = (padBytes: number) =>
         buildMapZip({ folder: 'Test', title: 'Test', artist: 'Artist', padBytes });
@@ -85,7 +105,8 @@ describe('validateMap', () => {
       );
 
       expect(readCounts[0]).toEqual(readCounts[1]);
-      expect(readCounts[0]).toBeLessThan(1024 * 1024);
+      // The scan window is ~64KB; anything beyond that means entry contents are being read.
+      expect(readCounts[0]).toBeLessThan(128 * 1024);
     });
   });
 
@@ -128,6 +149,22 @@ describe('validateMap', () => {
 
     it('a missing album art file', async () => {
       await expectError('Test_missing_album_art.zip', 'missing_album_art');
+    });
+
+    // Storage can fail partway through, once the archive is being read entry by entry. That has to
+    // come back as an error Result: a throw escaping here strands the upload mid-validation,
+    // because it's only rolled back on an error Result.
+    it('storage failing partway through reading the archive', async () => {
+      const buffer = readFixture('Test_valid.zip');
+      // The central directory is read first; the failure lands on an entry's contents.
+      const reader = new FailingReader(buffer, 2);
+
+      const result = await validateMap({ id: 'test', reader });
+
+      expect(result.success).toBe(false);
+      expect((result as Extract<typeof result, { success: false }>).errors[0].type).toEqual(
+        'no_data'
+      );
     });
   });
 });

--- a/src/services/maps/tests/map_validator.unit.test.ts
+++ b/src/services/maps/tests/map_validator.unit.test.ts
@@ -1,11 +1,35 @@
+import { Reader, Uint8ArrayReader } from '@zip.js/zip.js';
 import * as fs from 'fs';
 import * as path from 'path';
 import { validateMap } from 'services/maps/map_validator';
 import { readEntry } from 'services/maps/zip';
+import { buildMapZip } from './map_generator';
+
+class CountingReader extends Reader<Uint8Array> {
+  bytesRead = 0;
+  private readonly delegate: Uint8ArrayReader;
+
+  constructor(data: Uint8Array) {
+    super(data);
+    this.delegate = new Uint8ArrayReader(data);
+    this.size = data.byteLength;
+  }
+
+  async readUint8Array(index: number, length: number): Promise<Uint8Array> {
+    this.bytesRead += length;
+    return this.delegate.readUint8Array(index, length);
+  }
+}
 
 const readFixture = (name: string) => fs.readFileSync(path.resolve(__dirname, 'files', name));
 
-const validate = (name: string) => validateMap({ id: 'test', buffer: readFixture(name) });
+const validate = (name: string) => {
+  const buffer = readFixture(name);
+  return validateMap({
+    id: 'test',
+    archive: { reader: new Uint8ArrayReader(buffer), size: buffer.byteLength },
+  });
+};
 
 const expectError = async (name: string, type: string) => {
   const result = await validate(name);
@@ -42,6 +66,30 @@ describe('validateMap', () => {
       const bytes = await readEntry(albumArtFiles[0]);
       // JPEG start-of-image marker: the entry decompressed to the real album art.
       expect([bytes[0], bytes[1]]).toEqual([0xff, 0xd8]);
+    });
+
+    // The point of reading through a Reader: an archive is validated off its central directory and
+    // rlrr files, so blob storage never has to hand over the audio. What's read is bounded by the
+    // metadata plus zip.js' fixed-size scan for the central directory, not by the archive size.
+    it('reads a bounded amount regardless of how large the archive is', async () => {
+      const build = (padBytes: number) =>
+        buildMapZip({ folder: 'Test', title: 'Test', artist: 'Artist', padBytes });
+
+      const readCounts = await Promise.all(
+        [8 * 1024 * 1024, 32 * 1024 * 1024].map(async (padBytes) => {
+          const buffer = build(padBytes);
+          const reader = new CountingReader(buffer);
+          const result = await validateMap({
+            id: 'test',
+            archive: { reader, size: buffer.byteLength },
+          });
+          expect(result.success).toBe(true);
+          return reader.bytesRead;
+        })
+      );
+
+      expect(readCounts[0]).toEqual(readCounts[1]);
+      expect(readCounts[0]).toBeLessThan(1024 * 1024);
     });
   });
 

--- a/src/services/maps/tests/map_validator.unit.test.ts
+++ b/src/services/maps/tests/map_validator.unit.test.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { validateMap } from 'services/maps/map_validator';
+import { readEntry } from 'services/maps/zip';
 
 const readFixture = (name: string) => fs.readFileSync(path.resolve(__dirname, 'files', name));
 
@@ -30,6 +31,17 @@ describe('validateMap', () => {
     it('a valid map whose folder name matches the rlrr files', async () => {
       const result = await validate('Test_valid_different_folder_name.zip');
       expect(result.success).toBe(true);
+    });
+
+    // The album art entries outlive the call, and are only read later, when they're uploaded to S3.
+    it('returns album art entries that are still readable afterwards', async () => {
+      const result = await validate('Test_valid.zip');
+      const { albumArtFiles } = (result as Extract<typeof result, { success: true }>).value;
+      expect(albumArtFiles.length).toBeGreaterThan(0);
+
+      const bytes = await readEntry(albumArtFiles[0]);
+      // JPEG start-of-image marker: the entry decompressed to the real album art.
+      expect([bytes[0], bytes[1]]).toEqual([0xff, 0xd8]);
     });
   });
 

--- a/src/services/maps/tests/s3_handler.unit.test.ts
+++ b/src/services/maps/tests/s3_handler.unit.test.ts
@@ -1,8 +1,53 @@
-import { rangeHeader } from 'services/maps/s3_handler';
+import { GetObjectCommand, GetObjectCommandOutput } from '@aws-sdk/client-s3';
+import { ZipReader } from '@zip.js/zip.js';
+import { RangeGetter, S3RangeReader } from 'services/maps/s3_handler';
+import { buildMapZip } from './map_generator';
 
-describe('rangeHeader', () => {
-  it('is inclusive of the last requested byte', () => {
-    expect(rangeHeader(0, 100)).toEqual('bytes=0-99');
-    expect(rangeHeader(100, 1)).toEqual('bytes=100-100');
+class FakeS3 implements RangeGetter {
+  readonly ranges: (string | undefined)[] = [];
+
+  constructor(private readonly object: Buffer) {}
+
+  async send(command: GetObjectCommand): Promise<GetObjectCommandOutput> {
+    const range = command.input.Range;
+    this.ranges.push(range);
+    const [start, end] = (range ?? '').replace('bytes=', '').split('-').map(Number);
+    // S3 serves a range inclusive of both ends, and clamps one running past the object.
+    const bytes = this.object.subarray(start, Math.min(end + 1, this.object.byteLength));
+    return {
+      Body: { transformToByteArray: async () => bytes },
+    } as unknown as GetObjectCommandOutput;
+  }
+}
+
+const zip = buildMapZip({ folder: 'Test', title: 'Test', artist: 'Artist' });
+
+describe('S3RangeReader', () => {
+  it('requests ranges that are inclusive of the last byte', async () => {
+    const s3 = new FakeS3(zip);
+    const reader = new S3RangeReader(s3, 'bucket', 'key', zip.byteLength);
+
+    await reader.readUint8Array(10, 100);
+
+    expect(s3.ranges).toEqual(['bytes=10-109']);
+  });
+
+  it('reads an archive that S3 only ever serves in ranges', async () => {
+    const s3 = new FakeS3(zip);
+    const reader = new S3RangeReader(s3, 'bucket', 'key', zip.byteLength);
+
+    const entries = await new ZipReader(reader).getEntries();
+    const rlrr = entries.find((e) => e.filename.endsWith('.rlrr'));
+    const contents = await (rlrr as Extract<typeof rlrr, { directory: false }>).arrayBuffer();
+
+    expect(entries.map((e) => e.filename)).toContain('Test/Test_Easy.rlrr');
+    expect(JSON.parse(Buffer.from(contents).toString()).recordingMetadata.title).toEqual('Test');
+  });
+
+  it('throws when S3 returns no body', async () => {
+    const s3 = { send: async () => ({}) as GetObjectCommandOutput };
+    const reader = new S3RangeReader(s3, 'bucket', 'key', 100);
+
+    await expect(reader.readUint8Array(0, 10)).rejects.toThrow('Missing S3 body for key');
   });
 });

--- a/src/services/maps/tests/s3_handler.unit.test.ts
+++ b/src/services/maps/tests/s3_handler.unit.test.ts
@@ -1,0 +1,8 @@
+import { rangeHeader } from 'services/maps/s3_handler';
+
+describe('rangeHeader', () => {
+  it('is inclusive of the last requested byte', () => {
+    expect(rangeHeader(0, 100)).toEqual('bytes=0-99');
+    expect(rangeHeader(100, 1)).toEqual('bytes=100-100');
+  });
+});

--- a/src/services/maps/tests/s3_handler_fake_disk.unit.test.ts
+++ b/src/services/maps/tests/s3_handler_fake_disk.unit.test.ts
@@ -1,0 +1,45 @@
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { validateMap } from 'services/maps/map_validator';
+import { FileFakeS3Handler } from 'services/maps/s3_handler_fake_disk';
+import { buildMapZip } from './map_generator';
+
+let root: string;
+
+beforeAll(async () => {
+  root = await fs.mkdtemp(path.join(os.tmpdir(), 'paradb-dev-s3-'));
+  process.env.DEV_S3_ROOT = root;
+});
+
+afterAll(async () => {
+  await fs.rm(root, { recursive: true, force: true });
+});
+
+describe('FileFakeS3Handler', () => {
+  it('opens a stored archive for ranged reads', async () => {
+    const zip = buildMapZip({
+      folder: 'Test',
+      title: 'Test',
+      artist: 'Artist',
+      padBytes: 2 * 1024 * 1024,
+    });
+    await fs.mkdir(path.join(root, 'maps'), { recursive: true });
+    await fs.writeFile(path.join(root, 'maps', 'abc.zip.temp'), zip);
+
+    const opened = await new FileFakeS3Handler().openMapFile('abc', true);
+
+    expect(opened.success).toBe(true);
+    const { reader, size } = (opened as Extract<typeof opened, { success: true }>).value;
+    expect(size).toEqual(zip.byteLength);
+    // Reading through the reader is what exercises the ranged file reads.
+    const result = await validateMap({ id: 'abc', reader });
+    expect(result.success).toBe(true);
+  });
+
+  it('reports a missing archive rather than throwing', async () => {
+    const opened = await new FileFakeS3Handler().openMapFile('nonexistent', true);
+
+    expect(opened.success).toBe(false);
+  });
+});

--- a/src/services/maps/tests/zip.unit.test.ts
+++ b/src/services/maps/tests/zip.unit.test.ts
@@ -1,0 +1,82 @@
+import { ZipReader } from '@zip.js/zip.js';
+import { RangeReader } from 'services/maps/zip';
+import { buildMapZip } from './map_generator';
+
+class FakeRangeReader extends RangeReader {
+  readonly fetches: { index: number; length: number }[] = [];
+
+  constructor(private readonly data: Buffer) {
+    super('fake', data.byteLength);
+  }
+
+  // Deliberately a Buffer view at a non-zero offset, which is what both the S3 client and `fs`
+  // hand back, so a lost byte offset shows up here rather than in production.
+  protected async fetchRange(index: number, length: number): Promise<Uint8Array> {
+    this.fetches.push({ index, length });
+    return this.data.subarray(index, index + length);
+  }
+}
+
+const data = Buffer.from(Array.from({ length: 1000 }, (_, i) => i % 256));
+
+describe('RangeReader', () => {
+  it('serves reads contained in the cached tail without fetching again', async () => {
+    const reader = new FakeRangeReader(data);
+
+    const tail = await reader.readUint8Array(900, 100);
+    const withinTail = await reader.readUint8Array(950, 10);
+
+    expect(reader.fetches).toEqual([{ index: 900, length: 100 }]);
+    expect(tail).toEqual(Uint8Array.from(data.subarray(900)));
+    expect(withinTail).toEqual(Uint8Array.from(data.subarray(950, 960)));
+  });
+
+  it('fetches reads that fall outside the cached tail', async () => {
+    const reader = new FakeRangeReader(data);
+
+    await reader.readUint8Array(900, 100);
+    await reader.readUint8Array(0, 30);
+    // Straddling the start of the tail isn't served from it either.
+    await reader.readUint8Array(890, 20);
+
+    expect(reader.fetches).toEqual([
+      { index: 900, length: 100 },
+      { index: 0, length: 30 },
+      { index: 890, length: 20 },
+    ]);
+  });
+
+  it('does not cache a read that stops short of the end', async () => {
+    const reader = new FakeRangeReader(data);
+
+    await reader.readUint8Array(500, 100);
+    await reader.readUint8Array(550, 10);
+
+    expect(reader.fetches).toHaveLength(2);
+  });
+
+  it('truncates a read that runs past the end, and never fetches past it', async () => {
+    const reader = new FakeRangeReader(data);
+
+    const bytes = await reader.readUint8Array(990, 100);
+
+    expect(bytes).toEqual(Uint8Array.from(data.subarray(990)));
+    expect(reader.fetches).toEqual([{ index: 990, length: 10 }]);
+    expect(await reader.readUint8Array(1000, 10)).toEqual(new Uint8Array(0));
+  });
+
+  it('reads a real archive: central directory and end record in one fetch', async () => {
+    const zip = buildMapZip({
+      folder: 'Test',
+      title: 'Test',
+      artist: 'Artist',
+      padBytes: 1024 * 1024,
+    });
+    const reader = new FakeRangeReader(zip);
+
+    const entries = await new ZipReader(reader).getEntries();
+
+    expect(entries.length).toBeGreaterThan(0);
+    expect(reader.fetches).toHaveLength(1);
+  });
+});

--- a/src/services/maps/zip.ts
+++ b/src/services/maps/zip.ts
@@ -1,0 +1,19 @@
+import { FileEntry, configure } from '@zip.js/zip.js';
+
+// There are no web workers on the server, and inflating a map's metadata doesn't need them anyway.
+configure({ useWebWorkers: false });
+
+export async function readEntry(entry: FileEntry): Promise<Buffer> {
+  return Buffer.from(await entry.arrayBuffer());
+}
+
+// Zip entry names always use '/', regardless of the platform the archive was built on, so the
+// `path` equivalents would be wrong on Windows.
+export function zipBasename(filename: string): string {
+  return filename.substring(filename.lastIndexOf('/') + 1);
+}
+
+export function zipDirname(filename: string): string {
+  const separator = filename.lastIndexOf('/');
+  return separator === -1 ? '.' : filename.substring(0, separator);
+}

--- a/src/services/maps/zip.ts
+++ b/src/services/maps/zip.ts
@@ -1,7 +1,51 @@
-import { FileEntry, configure } from '@zip.js/zip.js';
+import { FileEntry, Reader, configure } from '@zip.js/zip.js';
 
 // There are no web workers on the server, and inflating a map's metadata doesn't need them anyway.
 configure({ useWebWorkers: false });
+
+/**
+ * A zip.js `Reader` over data whose ranges are expensive to fetch (a remote object, a file on
+ * disk). Subclasses only have to fetch a byte range; the tail is cached, so the scan for the
+ * end-of-central-directory record and the read of the central directory it points at - laid out
+ * immediately before it - cost one fetch rather than two.
+ */
+export abstract class RangeReader extends Reader<string> {
+  // Only the tail is worth keeping: zip.js scans a fixed-size window for the end-of-central-
+  // directory record, whereas an entry's data can be arbitrarily large.
+  private tail?: { index: number; bytes: Uint8Array };
+
+  constructor(name: string, size: number) {
+    super(name);
+    this.size = size;
+  }
+
+  protected abstract fetchRange(index: number, length: number): Promise<Uint8Array>;
+
+  async readUint8Array(index: number, length: number): Promise<Uint8Array> {
+    const available = Math.min(length, this.size - index);
+    if (available <= 0) {
+      return new Uint8Array(0);
+    }
+    const tail = this.tail;
+    if (
+      tail != null &&
+      index >= tail.index &&
+      index + available <= tail.index + tail.bytes.length
+    ) {
+      const start = index - tail.index;
+      return tail.bytes.subarray(start, start + available);
+    }
+    // zip.js reads records out of what it's handed with `slice()`, relying on it copying. A Buffer
+    // - which is what both the S3 client and `fs` hand back - slices to a view over a shared pool
+    // instead, losing the offset, and the parser then reads from the wrong place entirely.
+    const fetched = await this.fetchRange(index, available);
+    const bytes = new Uint8Array(fetched.buffer, fetched.byteOffset, fetched.byteLength);
+    if (index + bytes.length >= this.size) {
+      this.tail = { index, bytes };
+    }
+    return bytes;
+  }
+}
 
 export async function readEntry(entry: FileEntry): Promise<Buffer> {
   return Buffer.from(await entry.arrayBuffer());

--- a/src/services/maps/zip.ts
+++ b/src/services/maps/zip.ts
@@ -42,8 +42,8 @@ export abstract class RangeReader extends Reader<string> {
   }
 }
 
-export async function readEntry(entry: FileEntry): Promise<Buffer> {
-  return Buffer.from(await entry.arrayBuffer());
+export async function readEntry(entry: FileEntry): Promise<Uint8Array> {
+  return new Uint8Array(await entry.arrayBuffer());
 }
 
 // Zip entry names always use '/', regardless of the platform the archive was built on, so the

--- a/src/services/maps/zip.ts
+++ b/src/services/maps/zip.ts
@@ -3,15 +3,10 @@ import { FileEntry, Reader, configure } from '@zip.js/zip.js';
 // There are no web workers on the server, and inflating a map's metadata doesn't need them anyway.
 configure({ useWebWorkers: false });
 
-/**
- * A zip.js `Reader` over data whose ranges are expensive to fetch (a remote object, a file on
- * disk). Subclasses only have to fetch a byte range; the tail is cached, so the scan for the
- * end-of-central-directory record and the read of the central directory it points at - laid out
- * immediately before it - cost one fetch rather than two.
- */
+/** A zip.js `Reader` over data whose ranges are expensive to fetch: a remote object, a file on disk. */
 export abstract class RangeReader extends Reader<string> {
-  // Only the tail is worth keeping: zip.js scans a fixed-size window for the end-of-central-
-  // directory record, whereas an entry's data can be arbitrarily large.
+  // The central directory sits immediately before the end-of-central-directory record, so caching
+  // the tail covers both in one fetch. Only the tail: an entry's data can be arbitrarily large.
   private tail?: { index: number; bytes: Uint8Array };
 
   constructor(name: string, size: number) {


### PR DESCRIPTION
Replace unzipper with zip.js to support lazy, ranged archive reads. Archives are now read on-demand rather than fully buffered, making validation efficient even for large maps.

**Changes:**
- Swap unzipper for @zip.js/zip.js and remove unused dependencies (bluebird, fs-extra, readable-stream, etc.)
- Implement RangeReader abstraction for S3 and disk backends, serving only requested byte ranges
- Update validateMap to accept a Reader instead of a Buffer; validation now reads just the central directory and entry metadata
- Rename getMapFile → openMapFile to reflect the API change (returns MapArchive with Reader + size, not a Buffer)
- Update all S3 handler implementations (real, fake disk, fake memory) with ranged read support
- Add comprehensive unit tests for RangeReader, S3RangeReader, FileRangeReader, and validation with large archives
- Update e2e test helper to use zip.js

**Benefits:**
- No full archive in memory: even 100 MiB maps read ~64 KB for validation
- Bounded I/O: validation never touches audio payload, only metadata
- Storage-agnostic: RangeReader interface lets any source (S3, disk, network) feed zip.js
- Testable: new readers log fetch patterns; tests verify storage efficiency